### PR TITLE
try to make tapir 0.x.x and 1.x.x instrumentation live side-by-side

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -139,6 +139,7 @@ val instrumentationProjects = Seq[ProjectReference](
   `kamon-play`,
   `kamon-okhttp`,
   `kamon-tapir`,
+  `kamon-tapir-1`,
   `kamon-redis`,
   `kamon-caffeine`,
   `kamon-lagom`,
@@ -530,6 +531,25 @@ lazy val `kamon-tapir` = (project in file("instrumentation/kamon-tapir"))
     crossScalaVersions := Seq(`scala_2.12_version`, `scala_2.13_version`),
     libraryDependencies ++= Seq(
       kanelaAgent % "provided",
+      "com.softwaremill.sttp.tapir" %% "tapir-core" % "0.20.2" % "provided",
+      "com.typesafe.akka" %% "akka-http" % akkaHttpVersion(scalaBinaryVersion.value) % "provided",
+
+      "com.softwaremill.sttp.tapir" %% "tapir-akka-http-server" % "0.20.2" % "test",
+      "com.softwaremill.sttp.client3" %% "core" % "3.3.0-RC2" % "test",
+      scalatest % "test",
+      logbackClassic % "test",
+    )
+  )
+  .dependsOn(`kamon-core`, `kamon-akka-http`, `kamon-testkit` % "test")
+
+lazy val `kamon-tapir-1` = (project in file("instrumentation/kamon-tapir-1"))
+  .disablePlugins(AssemblyPlugin)
+  .enablePlugins(JavaAgent)
+  .settings(
+    instrumentationSettings,
+    crossScalaVersions := Seq(`scala_2.12_version`, `scala_2.13_version`),
+    libraryDependencies ++= Seq(
+      kanelaAgent % "provided",
       "com.softwaremill.sttp.tapir" %% "tapir-core" % "1.0.1" % "provided",
       "com.typesafe.akka" %% "akka-http" % akkaHttpVersion(scalaBinaryVersion.value) % "provided",
 
@@ -538,7 +558,7 @@ lazy val `kamon-tapir` = (project in file("instrumentation/kamon-tapir"))
       scalatest % "test",
       logbackClassic % "test",
     )
-  ).dependsOn(`kamon-core`, `kamon-akka-http`, `kamon-testkit` % "test")
+  ).dependsOn(`kamon-core`, `kamon-akka-http`, `kamon-tapir`, `kamon-testkit` % "test")
 
 lazy val `kamon-redis` = (project in file("instrumentation/kamon-redis"))
   .disablePlugins(AssemblyPlugin)
@@ -929,6 +949,7 @@ lazy val `kamon-bundle-dependencies-2-12-and-up` = (project in file("bundle/kamo
     `kamon-akka-grpc`,
     `kamon-finagle`,
     `kamon-tapir`,
+    `kamon-tapir-1`,
     `kamon-alpakka-kafka`
   )
 

--- a/instrumentation/kamon-tapir-1/src/main/resources/reference.conf
+++ b/instrumentation/kamon-tapir-1/src/main/resources/reference.conf
@@ -1,0 +1,16 @@
+# =================================== #
+# kamon-tapir reference configuration #
+# =================================== #
+
+kamon.instrumentation.tapir {
+
+  # Controls whether Kamon will use the endpoint name as the Server-side Spans operation name
+  use-endpoint-name-as-operation-name = no
+}
+
+kanela.modules {
+  tapir.instrumentations = [
+    "kamon.instrumentation.tapir.TapirInstrumentation_0",
+    "kamon.instrumentation.tapir.TapirInstrumentation_1"
+  ]
+}

--- a/instrumentation/kamon-tapir-1/src/main/scala/kamon/instrumentation/tapir/TapirInstrumentation.scala
+++ b/instrumentation/kamon-tapir-1/src/main/scala/kamon/instrumentation/tapir/TapirInstrumentation.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kamon.instrumentation.tapir
+
+import kanela.agent.api.instrumentation.InstrumentationBuilder
+import kanela.agent.api.instrumentation.classloader.ClassRefiner
+import sttp.tapir.server.ServerEndpoint
+
+class TapirInstrumentation_1 extends InstrumentationBuilder {
+    onTypes("sttp.tapir.server.akkahttp.EndpointToAkkaServer",
+      "sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter")
+      .when(ClassRefiner.builder().mustContain("sttp.tapir.server.ServerEndpoint").withMethods("showPathTemplate"))
+      .intercept(method("toRoute"), classOf[TapirToRouteInterceptor_1])
+}
+
+class TapirToRouteInterceptor_1
+
+object TapirToRouteInterceptor_1 extends InterceptorMethods  {
+  override def pathTemplate(endpoint: SE): String = endpoint.showPathTemplate()
+}

--- a/instrumentation/kamon-tapir-1/src/test/scala/kamon/instrumentation/tapir/TapirAkkaHttpServer.scala
+++ b/instrumentation/kamon-tapir-1/src/test/scala/kamon/instrumentation/tapir/TapirAkkaHttpServer.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kamon.instrumentation.tapir
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+object TapirAkkaHttpServer {
+  implicit val actorSystem: ActorSystem = ActorSystem()
+
+  import actorSystem.dispatcher
+
+  private var server: Future[Http.ServerBinding] = _
+
+  def start = {
+    server = Http().newServerAt("localhost", 8080).bindFlow(TestRoutes.routes)
+  }
+
+  def stop = server.flatMap(x => x.terminate(5.seconds))
+
+}

--- a/instrumentation/kamon-tapir-1/src/test/scala/kamon/instrumentation/tapir/TapirSpec.scala
+++ b/instrumentation/kamon-tapir-1/src/test/scala/kamon/instrumentation/tapir/TapirSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kamon.instrumentation.tapir
+
+import kamon.testkit.TestSpanReporter
+import org.scalatest.concurrent.Eventually
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{BeforeAndAfterAll, OptionValues}
+import sttp.client3.{HttpURLConnectionBackend, Identity, SttpBackend, UriContext, asStringAlways, basicRequest}
+
+import scala.concurrent.duration.DurationInt
+
+class TapirSpec extends AnyWordSpec with Matchers
+  with TestSpanReporter
+  with Eventually
+  with BeforeAndAfterAll
+  with OptionValues {
+
+  var backend: SttpBackend[Identity, Any] = _
+
+  override def beforeAll() = {
+    backend = HttpURLConnectionBackend()
+    TapirAkkaHttpServer.start
+  }
+
+  override def afterAll() = {
+    TapirAkkaHttpServer.stop
+    backend.close()
+  }
+
+
+  "the Tapir Akka HTTP instrumentation" should {
+    "replace params in path when naming span" in {
+      basicRequest
+        .response(asStringAlways)
+        .get(uri"http://localhost:8080/hello/frodo").send(backend)
+        .body
+
+      eventually(timeout(2.seconds)) {
+        val span = testSpanReporter().nextSpan()
+        span.map { s =>
+          s.operationName shouldBe "/hello/{param1}"
+        }
+      }
+    }
+
+    "replace params with mixed type params when naming span" in {
+      basicRequest
+        .response(asStringAlways)
+        .get(uri"http://localhost:8080/nested/path/with/3/mixed/true/types").send(backend)
+        .body
+
+      eventually(timeout(2.seconds)) {
+        val span = testSpanReporter().nextSpan()
+        span.map { s =>
+          s.operationName shouldBe "/nested/{param1}/with/{param2}/mixed/{param3}/types"
+        }
+      }
+    }
+  }
+}

--- a/instrumentation/kamon-tapir-1/src/test/scala/kamon/instrumentation/tapir/TestRoutes.scala
+++ b/instrumentation/kamon-tapir-1/src/test/scala/kamon/instrumentation/tapir/TestRoutes.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kamon.instrumentation.tapir
+
+import akka.http.scaladsl.server.Directives._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
+import sttp.tapir.{endpoint, path, plainBody}
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object TestRoutes {
+
+  // hello/{}
+  private val hello = endpoint.get
+    .in("hello").in(path[String])
+    .out(plainBody[String])
+  private val helloRoute = AkkaHttpServerInterpreter().toRoute(
+    hello.serverLogic[Future] { name => Future.successful(Right(name)) }
+  )
+
+  // hello/{}/with/{}/mixed/{}/types
+  private val nested = endpoint.get
+    .in("nested").in(path[String]("integer_param"))
+    .in("with").in(path[Int])
+    .in("mixed").in(path[Boolean]("other_param"))
+    .in("types").out(plainBody[String])
+  private val nestedRoute = AkkaHttpServerInterpreter().toRoute(
+    nested.serverLogic[Future] { x => Future.successful(Right[Unit,String](x.toString())) }
+  )
+
+  val routes = helloRoute ~ nestedRoute
+}

--- a/instrumentation/kamon-tapir/src/main/resources/reference.conf
+++ b/instrumentation/kamon-tapir/src/main/resources/reference.conf
@@ -13,7 +13,8 @@ kanela.modules {
     name = "Tapir"
     description = "Uses Tapir routes to generate operation names. Currently supports only Akka Http"
     instrumentations = [
-      "kamon.instrumentation.tapir.TapirInstrumentation"
+      "kamon.instrumentation.tapir.TapirInstrumentation_0",
+      "kamon.instrumentation.tapir.TapirInstrumentation_1"
     ]
     within = [
       "^sttp.tapir.server.akkahttp.*"

--- a/instrumentation/kamon-tapir/src/main/scala/kamon/instrumentation/tapir/TapirInstrumentation.scala
+++ b/instrumentation/kamon-tapir/src/main/scala/kamon/instrumentation/tapir/TapirInstrumentation.scala
@@ -21,22 +21,24 @@ import kamon.Kamon
 import kanela.agent.api.instrumentation.InstrumentationBuilder
 import kanela.agent.libs.net.bytebuddy.implementation.bind.annotation.{Argument, SuperCall}
 import sttp.tapir.server.ServerEndpoint
-
 import java.util.concurrent.Callable
 
-class TapirInstrumentation extends InstrumentationBuilder {
+import kanela.agent.api.instrumentation.classloader.ClassRefiner
+
+class TapirInstrumentation_0 extends InstrumentationBuilder {
   onTypes("sttp.tapir.server.akkahttp.EndpointToAkkaServer",
     "sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter")
-    .intercept(method("toRoute"), classOf[TapirToRouteInterceptor])
+    .when(ClassRefiner.builder().mustContain("sttp.tapir.server.ServerEndpoint").withMethod("renderPathTemplate"))
+    .intercept(method("toRoute"), classOf[TapirToRouteInterceptor_0])
 }
 
-class TapirToRouteInterceptor
-
-object TapirToRouteInterceptor {
+trait InterceptorMethods {
+  type SE = ServerEndpoint[_, T forSome { type T[_] }]
+  def pathTemplate(endpoint: SE): String
 
   def toRoute[I, E, O](@Argument(0) arg: Any, @SuperCall superCall: Callable[Route]): Route = {
     arg match {
-      case endpoint : ServerEndpoint[_,_] => {
+      case endpoint: ServerEndpoint[_, _] => {
         val originalRoute = superCall.call()
 
         req => {
@@ -45,7 +47,7 @@ object TapirToRouteInterceptor {
 
           val operationName = endpoint.info.name match {
             case Some(endpointName) if useEndpointNameAsOperationName => endpointName
-            case _ => endpoint.showPathTemplate()
+            case _ => pathTemplate(endpoint)
           }
 
           Kamon.currentSpan()
@@ -60,4 +62,10 @@ object TapirToRouteInterceptor {
         superCall.call()
     }
   }
+
+}
+class TapirToRouteInterceptor_0
+
+object TapirToRouteInterceptor_0 extends InterceptorMethods {
+  override def pathTemplate(endpoint: SE): String = endpoint.renderPathTemplate()
 }


### PR DESCRIPTION
- It's not especially pretty (pulling in kamon-tapir without kamon-tapir-1 will produce the warning `Error trying to load Instrumentation: kamon.instrumentation.tapir.TapirInstrumentation_1 with error: java.lang.ClassNotFoundException: kamon.instrumentation.tapir.TapirInstrumentation_1`) but this should produce a cleaner upgrade path, permitting users to upgrade kamon before/without upgrading tapir